### PR TITLE
#11038 allow for searching RDA preferences

### DIFF
--- a/lib/homeflow/api/rda_agency_preference.rb
+++ b/lib/homeflow/api/rda_agency_preference.rb
@@ -4,6 +4,10 @@ module Homeflow
 
       is_resource :rda_agency_preferences
 
+      def self.find_by_agency_id(agency_id)
+        Request.run_for(Homeflow::API::ResourceIdentifier.new("/rda_agency_preferences/#{agency_id}"))
+      end
+
     end
   end
 end


### PR DESCRIPTION
Searching for a set of RDA preferences without this seemed to give a bad URL due to the URL.  The easiest solution is to specify a find_by_agency_id which has a route defined in the call.