### PR TITLE
Don't mask original exception on connection failure

### DIFF
--- a/lib/homeflow/api/request.rb
+++ b/lib/homeflow/api/request.rb
@@ -16,7 +16,7 @@ module Homeflow
       begin
         response = body_of_request(perform_request)
       rescue Errno::ECONNREFUSED => e
-        raise Homeflow::API::Exceptions::APIConnectionError, "Connection error. Homeflow might be down?"
+        raise Homeflow::API::Exceptions::APIConnectionError, "Homeflow might be down? Connection error: #{e}"
       end
       response
     end

--- a/lib/homeflow/api/response.rb
+++ b/lib/homeflow/api/response.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 module Homeflow
 
   module API


### PR DESCRIPTION
Also require `multi_json` where needed (tests were failing otherwise)